### PR TITLE
plugin now caches temp graphs and the recent graph

### DIFF
--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/manager.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/manager.py
@@ -102,6 +102,7 @@ class PictonodeManager(metaclass=SingletonConstruction):
 
         self.toolbar = ProjectToolbar()
         self.main_window = window.PluginWindow()
+        self.main_window.load_graph(self.settings_ini["SETTINGS"]["STARTUP"])
 
         self.image_displays = {}
         self.image_names = {}
@@ -126,6 +127,11 @@ class PictonodeManager(metaclass=SingletonConstruction):
         theme_name = "Adwaita"
         settings = Gtk.Settings.get_default()
         settings.set_property("gtk-theme-name", theme_name)
+    
+    @threadsafe
+    def set_startup_graph(self, filepath):
+        self.settings_ini["SETTINGS"]["STARTUP"] = filepath
+        self.__save_settings_ini()
 
     def __update(self):
         try:
@@ -237,7 +243,7 @@ class PictonodeManager(metaclass=SingletonConstruction):
         with open(self.settings_ini_path, "w") as ini:
             if default:
                 default = configparser.SafeConfigParser()
-                default["SETTINGS"] = {}
+                default["SETTINGS"] = {"STARTUP":""}
                 default.write(ini)
             else:
                 self.settings_ini.write(ini)

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
@@ -9,6 +9,7 @@ from json_interpreter import *
 from login_window import LoginBox
 from about import AboutDialog
 
+import datetime
 import sys
 import threading
 import os
@@ -85,6 +86,7 @@ class PluginWindow(Gtk.Window):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.temp_target_file = ""
         self.set_border_width(20)
         self.set_title("Pictonode")
 
@@ -232,6 +234,7 @@ class PluginWindow(Gtk.Window):
 
         if os.path.isfile(filepath):
             with open(filepath) as f:
+                self.temp_target_file = os.path.splitext(os.path.basename(filepath))[0]
                 json_string = json.load(f)
 
                 try:
@@ -241,6 +244,8 @@ class PluginWindow(Gtk.Window):
 
                 self.node_view.show_all()
                 self.set_layers(self.layers)
+        else:
+            self.temp_target_file = timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
             
         return None
     
@@ -498,6 +503,7 @@ class PluginWindow(Gtk.Window):
                 json.dump(dictionary, outfile, indent=2)
             
             PictonodeManager().set_startup_graph(fn)
+            self.temp_target_file = os.path.splitext(os.path.basename(fn))[0]
 
             save_dialog.destroy()
             return None
@@ -507,7 +513,8 @@ class PluginWindow(Gtk.Window):
     
     def save_temp(self):
         from manager import PictonodeManager
-        temp = os.path.realpath(os.path.dirname(os.path.abspath(__file__)) + "/cache/temp.json")
+        basename = self.temp_target_file
+        temp = os.path.realpath(os.path.dirname(os.path.abspath(__file__)) + f"/cache/{basename}-temp.json")
         dictionary = serialize_nodes(self.node_view)
         with open(temp, "w") as outfile:
                 json.dump(dictionary, outfile, indent=2)
@@ -555,8 +562,9 @@ class PluginWindow(Gtk.Window):
                 json_interpreter(self.node_view, self, json_string=json_string)
             except Exception as E:
                 print(E)
-                
+
             PictonodeManager().set_startup_graph(fn)
+            self.temp_target_file = os.path.splitext(os.path.basename(fn))[0]
             self.node_view.show_all()
             self.set_layers(self.layers)
 


### PR DESCRIPTION
epic last minute pogger feature that looks juicy for demos, here's the showcase:

[![IMAGE ALT TEXT HERE](https://user-images.githubusercontent.com/67705843/233747188-f9810bd3-ec03-4935-8017-af05f4a04c4b.png)](https://user-images.githubusercontent.com/67705843/233746979-9ffc659b-272f-46ff-b2c8-632e22d748d7.mp4)

### Summary:
- Last worked on graph becomes startup graph
- Clear the startup graph settings button

Of course providing gui access to unsaved graphs and making them not overwrite one another are things to add but good enough for the moment.