### PR TITLE
Crash fixes

### DIFF
--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/custom_nodes.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/custom_nodes.py
@@ -47,6 +47,7 @@ from gi.repository import GLib # noqa
 # First, define generic custom node type using GtkNodes.Node as a base type
 # implement gegl node operations using ontario backend
 
+g_NodeView = None
 
 class CustomNode(GtkNodes.Node):
 
@@ -71,7 +72,8 @@ class CustomNode(GtkNodes.Node):
         dialog.destroy()
 
         if response == Gtk.ResponseType.OK:
-            self.destroy()
+            global g_NodeView
+            g_NodeView.remove(self)
 
     def get_values(self):
         return {}

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/custom_nodes.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/custom_nodes.py
@@ -1466,10 +1466,13 @@ class WaterpixelNode(CustomNode):
     def process_input(self):
 
         def increment_spinner():
-            next_dot_count = (self.dot_count + 1) % 4
-            self.busy_box.set_message(f"Processing{next_dot_count*'.'}")
-            self.dot_count = next_dot_count
-            GLib.timeout_add(500, increment_spinner)
+            try:
+                next_dot_count = (self.dot_count + 1) % 4
+                self.busy_box.set_message(f"Processing{next_dot_count*'.'}")
+                self.dot_count = next_dot_count
+                GLib.timeout_add(500, increment_spinner)
+            except:
+                pass
             return False
 
         def add_spinner():
@@ -1712,10 +1715,13 @@ class TileGlassNode(CustomNode):
     def process_input(self):
 
         def increment_spinner():
-            next_dot_count = (self.dot_count + 1) % 4
-            self.busy_box.set_message(f"Processing{next_dot_count*'.'}")
-            self.dot_count = next_dot_count
-            GLib.timeout_add(500, increment_spinner)
+            try:
+                next_dot_count = (self.dot_count + 1) % 4
+                self.busy_box.set_message(f"Processing{next_dot_count*'.'}")
+                self.dot_count = next_dot_count
+                GLib.timeout_add(500, increment_spinner)
+            except:
+                pass
             return False
 
         def add_spinner():

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/manager.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/manager.py
@@ -126,6 +126,10 @@ class PictonodeManager(metaclass=SingletonConstruction):
 
         Gtk.main()
 
+    @threadsafe
+    def notify_quit(self):
+        Gtk.main_quit()
+
     def set_gtk_theme(theme_name="Adwaita"):
         theme_name = "Adwaita"
         settings = Gtk.Settings.get_default()

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/toolbar.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/toolbar.py
@@ -66,7 +66,11 @@ class ProjectToolbar(Gtk.Window):
         self.iconview.connect("selection-changed", self.icon_clicked)
         self.init = True
 
-        self.connect("destroy", Gtk.main_quit)
+        def do_quit(_):
+            from manager import PictonodeManager
+            PictonodeManager().notify_quit()
+
+        self.connect("destroy", do_quit)
 
     def icon_clicked(self, widget: Gtk.IconView):
         if self.mode != "Debug":

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
@@ -641,15 +641,14 @@ class PluginWindow(Gtk.Window):
             if self.save_semaphore.acquire():
                 if self.serialization != new_serialization:
                     self.serialization = new_serialization
-                    temp = os.path.realpath(os.path.dirname(os.path.abspath(__file__)) + f"/cache/{basename.replace('-temp', )}-temp.json")
-                    
+                    temp = os.path.realpath(os.path.dirname(os.path.abspath(__file__)) + f"/cache/{basename.replace('-temp', '')}-temp.json")
                     
                     with open(temp, "w") as outfile:
                         json.dump(self.serialization, outfile, indent=2)
 
                     print(f"{GLib.get_current_time()} - saved")
-                    self.save_semaphore.release()
                     PictonodeManager().set_startup_graph(temp)
+                    self.save_semaphore.release()
                 else:
                     print(f"{GLib.get_current_time()} - not saved (cached)")
         else:

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
@@ -206,6 +206,7 @@ class PluginWindow(Gtk.Window):
         image_frame.add(self.image_scrolled)
 
         self.node_view: GtkNodes.NodeView = GtkNodes.NodeView()
+        cn.g_NodeView = self.node_view
         scrolled_window.add(self.node_view)
 
         # create context menu in node view

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
@@ -641,15 +641,11 @@ class PluginWindow(Gtk.Window):
             if self.save_semaphore.acquire():
                 if self.serialization != new_serialization:
                     self.serialization = new_serialization
-                    temp = os.path.realpath(os.path.dirname(os.path.abspath(__file__)) + f"/cache/{basename.replace('-temp','')}-temp.json")
-                    temp_log = os.path.realpath(os.path.dirname(os.path.abspath(__file__)) + f"/cache/{basename.replace('-temp-log','')}-temp-log.json")
+                    temp = os.path.realpath(os.path.dirname(os.path.abspath(__file__)) + f"/cache/{basename.replace('-temp', '')}-temp.json")
+                    
                     
                     with open(temp, "w") as outfile:
                         json.dump(self.serialization, outfile, indent=2)
-
-                    with open(temp_log, "a") as outfile_log:
-                        outfile_log.write(f"\n\n{80*'='}\n\n")
-                        json.dump(self.serialization, outfile_log, indent=2)
 
                     print(f"{GLib.get_current_time()} - saved")
                     self.save_semaphore.release()

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
@@ -641,7 +641,7 @@ class PluginWindow(Gtk.Window):
             if self.save_semaphore.acquire():
                 if self.serialization != new_serialization:
                     self.serialization = new_serialization
-                    temp = os.path.realpath(os.path.dirname(os.path.abspath(__file__)) + f"/cache/{basename.replace('-temp', '')}-temp.json")
+                    temp = os.path.realpath(os.path.dirname(os.path.abspath(__file__)) + f"/cache/{basename.replace('-temp', )}-temp.json")
                     
                     
                     with open(temp, "w") as outfile:
@@ -721,4 +721,7 @@ class PluginWindow(Gtk.Window):
         self.image.set_from_file("/tmp/gimp/temp.png")
         self.pixbuf = self.image.get_pixbuf()
 
-        self.__draw_zoomed_image()
+        try:
+            self.__draw_zoomed_image()
+        except:
+            pass


### PR DESCRIPTION
Bit hacky but took action against the following 4 crashes:
 - Terminating any window does not properly terminate the process, segfault via multiple Gtk.main_quits()
     - **Solution:** Created threadsafe `notify_quit()` in manager that any window is free to call any time. Windows must not call Gtk.main_quit() themselves.
     
 - Deleting any node type ***could*** put the plugin into an unstable state.
     - **Solution:** Replaced unsafe `node.destroy()` with `g_NodeView.remove(node)` 
     
 - Deleting the output node ***would*** put the plugin into an unstable state.
     - **Solution:** Replaced unsafe `node.destroy()` with `g_NodeView.remove(node)`
     
 - Gdk Event Processing starved in the main thread by many sequential disk writes
     - **Solution:** Save requests are now performed asynchronously. Any save requests check lock check their serialized version of the graphs against the cached version before confirming a disk write.

Please try to reproduce these guys @parkern342 